### PR TITLE
add ability to parse expressions inside tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,7 @@ env.addExtension('DoExtension', new DoExtension());
 test = { hello: 'world' }
 {% enddo %}
 ```
+or
+```html
+{% do test = { hello: 'world' } %}
+```

--- a/test.js
+++ b/test.js
@@ -17,4 +17,9 @@ describe('nunjucks-do', function() {
         }).should.equal('So Cool');
     });
 
+    it('should eval js in tag', function() {
+        env.renderString('{% do test = "So " + test %}{{ test }}', {
+            test: 'Cool'
+        }).should.equal('So Cool');
+    });
 });


### PR DESCRIPTION
For my own project, wanted to simplify usage a little bit, bring it closer to jinja.

This allows parsing js expressions from the tag contents instead of the block body. As in:
```html
{% do test = { hello: 'world' } %}
```

Errors if both are used.